### PR TITLE
Support 3d geometry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WellKnownGeometry"
 uuid = "0f680547-7be7-4555-8820-bb198eeb646b"
 authors = ["Maarten Pronk <git@evetion.nl>", "Julia Computing and contributors."]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 GeoFormatTypes = "68eda718-8dee-11e9-39e7-89f7f65f511f"
@@ -14,7 +14,8 @@ julia = "1.6"
 
 [extras]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
+LibGEOS = "a90b1aa1-3769-5649-ba7e-abc5a9d163eb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ArchGDAL"]
+test = ["Test", "ArchGDAL", "LibGEOS"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,23 +3,34 @@ import GeoFormatTypes as GFT
 import GeoInterface as GI
 using Test
 import ArchGDAL
+import LibGEOS
 
 @testset "WellKnownGeometry.jl" begin
 
     coord = [1.1, 2.2]
+    coord3 = [1.1, 2.2, 3.3]
     lcoord = [3.3, 4.4]
+    lcoord3 = [3.3, 4.4, 5.5]
     ring = [[0.1, 0.2], [0.3, 0.4], [0.1, 0.2]]
+    ring3 = [[0.1, 0.2, 0.3], [0.3, 0.4, 0.5], [0.1, 0.2, 0.3]]
     coords = [[coord, lcoord, coord], ring]
+    coords3 = [[coord3, lcoord3, coord3], ring3]
 
-    for (type, geom) in (
-        ("Point", ArchGDAL.createpoint(coord)),
-        ("LineString", ArchGDAL.createlinestring([coord, lcoord])),
-        ("Polygon", ArchGDAL.createpolygon(coords)),
-        ("MultiPoint", ArchGDAL.createmultipoint([coord, lcoord])),
-        ("MultiLineString", ArchGDAL.createmultilinestring([[coord, lcoord], [coord, lcoord]])),
-        ("MultiPolygon", ArchGDAL.createmultipolygon([coords, coords])),
-        ("Empty", ArchGDAL.createpoint()),
-        ("Empty Multi", ArchGDAL.createmultipolygon())
+    for (type, geom, broken) in (
+        ("Point", ArchGDAL.createpoint(coord), false),
+        ("PointZ", ArchGDAL.createpoint(coord3), true),
+        ("LineString", ArchGDAL.createlinestring([coord, lcoord]), false),
+        ("LineStringZ", ArchGDAL.createlinestring([coord3, lcoord3]), true),
+        ("Polygon", ArchGDAL.createpolygon(coords), false),
+        ("PolygonZ", ArchGDAL.createpolygon(coords3), true),
+        ("MultiPoint", ArchGDAL.createmultipoint([coord, lcoord]), false),
+        ("MultiPointZ", ArchGDAL.createmultipoint([coord3, lcoord3]), true),
+        ("MultiLineString", ArchGDAL.createmultilinestring([[coord, lcoord], [coord, lcoord]]), false),
+        ("MultiLineStringZ", ArchGDAL.createmultilinestring([[coord3, lcoord3], [coord3, lcoord3]]), true),
+        ("MultiPolygon", ArchGDAL.createmultipolygon([coords, coords]), false),
+        ("MultiPolygonZ", ArchGDAL.createmultipolygon([coords3, coords3]), true),
+        ("Empty", ArchGDAL.createpoint(), false),
+        ("Empty Multi", ArchGDAL.createmultipolygon(), false)
     )
         @testset "$type" begin
             @testset "WKB" begin
@@ -29,17 +40,21 @@ import ArchGDAL
                 @test all(wkb .== wkbc)
                 ArchGDAL.fromWKB(wkb)
                 gwkb = GFT.WellKnownBinary(GFT.Geom(), wkb)
-                @test all(GI.coordinates(gwkb) .== GI.coordinates(geom))
+                if !occursin("Empty", type)  # broken on ArchGDAL
+                    @test GI.ncoord(gwkb) == GI.ncoord(geom)
+                end
+                @test GI.coordinates(gwkb) == GI.coordinates(geom)
             end
             @testset "WKT" begin
                 wkt = WKG.getwkt(geom)
                 wktc = ArchGDAL.toWKT(geom)
-                @test wkt == wktc
+                @test wkt == wktc broken = broken
                 # Test validity by reading it again
                 ArchGDAL.fromWKT(wkt)
                 gwkt = GFT.WellKnownText(GFT.Geom(), wkt)
-                if type !== "Empty"  # broken on ArchGDAL
-                    @test all(GI.coordinates(gwkt) .== GI.coordinates(geom))
+                if !occursin("Empty", type)  # broken on ArchGDAL
+                    @test GI.ncoord(gwkt) == GI.ncoord(geom)
+                    @test GI.coordinates(gwkt) == GI.coordinates(geom)
                 end
             end
         end
@@ -83,4 +98,67 @@ import ArchGDAL
         @test GI.isgeometry(wkb)
 
     end
+
+    @testset "LibGEOS" begin
+        p = LibGEOS.readgeom("POLYGON Z ((0.5 0.5 0.5,1.5 0.5 0.5,1.5 1.5 0.5,0.5 0.5 0.5))")
+        # LibGEOS has a space between points
+        @test replace(WKG.getwkt(p), " " => "") == replace(LibGEOS.writegeom(p), " " => "")
+        wkbwriter = LibGEOS.WKBWriter(LibGEOS._context)
+        @test WKG.getwkb(p) == LibGEOS.writegeom(p, wkbwriter) broken = true  # LibGEOS doesn't provide 3D type
+    end
+
+    @testset "ZM" begin
+        wkb = GFT.WellKnownBinary(GFT.Geom(),
+            [
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x80,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xf0,
+                0x3f,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xf0,
+                0x3f,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xf0,
+                0x3f,
+            ])
+        @test GI.isgeometry(wkb)
+        @test GI.geomtrait(wkb) == GI.PointTrait()
+        @test GI.ncoord(wkb) == 3
+        @test GI.coordinates(wkb) == [1.0, 1.0, 1.0]
+
+        wkt = GFT.WellKnownText(GFT.Geom(), "POINTM (1 1 1)")
+        @test GI.isgeometry(wkt)
+        @test GI.geomtrait(wkt) == GI.PointTrait()
+        @test GI.ncoord(wkt) == 3
+        @test GI.coordinates(wkt) == [1.0, 1.0, 1.0]
+
+        wkt = GFT.WellKnownText(GFT.Geom(), "POINTZM (1 1 1 1)")
+        @test GI.isgeometry(wkt)
+        @test GI.geomtrait(wkt) == GI.PointTrait()
+        @test GI.ncoord(wkt) == 4
+        @test GI.coordinates(wkt) == [1.0, 1.0, 1.0, 1.0]
+
+    end
+
+
+
 end


### PR DESCRIPTION
However, it's not straightforward to be compatible with 3th-party packages.

There are several flavors of 2d+ WKT/WKB. WKT should print Z, M, ZM in their type, but GDAL omits this when possible and only provides it for M. ArchGDAL doesn't fully Z/M geometries, so this is sometimes hard to test. WKB has two ways of providing the geometry type, one with bitflags, one with x-thousands added to the type. We parse both, but only write the flagged one, which seems to be default. Interestingly, LibGEOS(.jl) doesn't seem to support either.

Also improved parsing of type with regex.