### PR TITLE
Always return a GeoFormatType.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WellKnownGeometry"
 uuid = "0f680547-7be7-4555-8820-bb198eeb646b"
 authors = ["Maarten Pronk <git@evetion.nl>", "Julia Computing and contributors."]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 GeoFormatTypes = "68eda718-8dee-11e9-39e7-89f7f65f511f"

--- a/src/wkb.jl
+++ b/src/wkb.jl
@@ -14,7 +14,7 @@ is true for a GeometryCollection, when the subgeometry types are not known befor
 
 # Map GeoInterface type traits directly to their WKB UInt32 interpretation
 
-const geowkb = Dict{DataType, UInt32}(
+const geowkb = Dict{DataType,UInt32}(
     GI.PointTrait => UInt32(1),
     GI.LineStringTrait => UInt32(2),
     GI.PolygonTrait => UInt32(3),
@@ -23,7 +23,7 @@ const geowkb = Dict{DataType, UInt32}(
     GI.MultiPolygonTrait => UInt32(6),
     GI.GeometryCollectionTrait => UInt32(7),
 )
-const wkbgeo = Dict{UInt32, DataType}(zip(values(geowkb), keys(geowkb)))
+const wkbgeo = Dict{UInt32,DataType}(zip(values(geowkb), keys(geowkb)))
 geometry_code(T) = geowkb[typeof(T)]
 
 """
@@ -34,7 +34,7 @@ Retrieve the Well Known Binary (WKB) as `Vector{UInt8}` for a `geom` that implem
 function getwkb(geom)
     data = UInt8[]
     getwkb!(data, GI.geomtrait(geom), geom, true)
-    return data
+    return GFT.WellKnownBinary(GFT.Geom(), data)
 end
 
 """

--- a/src/wkt.jl
+++ b/src/wkt.jl
@@ -20,7 +20,7 @@ POLYGON (((35 10, 45 45, 15 40, 10 20, 35 10),
 """
 
 # Map GeoInterface type traits directly to their WKT String representation
-const geowkt = Dict{DataType, String}(
+const geowkt = Dict{DataType,String}(
     GI.PointTrait => "POINT ",
     GI.LineStringTrait => "LINESTRING ",
     GI.PolygonTrait => "POLYGON ",
@@ -29,7 +29,7 @@ const geowkt = Dict{DataType, String}(
     GI.MultiPolygonTrait => "MULTIPOLYGON ",
     GI.GeometryCollectionTrait => "GEOMETRYCOLLECTION "
 )
-const wktgeo = Dict{String, DataType}(zip(values(geowkt), keys(geowkt)))
+const wktgeo = Dict{String,DataType}(zip(values(geowkt), keys(geowkt)))
 geometry_string(T) = geowkt[typeof(T)]
 
 """
@@ -40,7 +40,7 @@ Retrieve the Well Known Text (WKT) as `String` for a `geom` that implements the 
 function getwkt(geom)
     data = Char[]
     getwkt!(data, GI.geomtrait(geom), geom, true)
-    return String(data)
+    return GFT.WellKnownText(GFT.Geom(), String(data))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,21 +25,19 @@ import ArchGDAL
             @testset "WKB" begin
                 wkb = WKG.getwkb(geom)
                 wkbc = ArchGDAL.toWKB(geom)
-                @test length(wkb) == length(wkbc)
-                @test all(wkb .== wkbc)
-                ArchGDAL.fromWKB(wkb)
-                gwkb = GFT.WellKnownBinary(GFT.Geom(), wkb)
-                @test all(GI.coordinates(gwkb) .== GI.coordinates(geom))
+                @test length(GFT.val(wkb)) == length(wkbc)
+                @test all(GFT.val(wkb) .== wkbc)
+                ArchGDAL.fromWKB(GFT.val(wkb))
+                @test all(GI.coordinates(wkb) .== GI.coordinates(geom))
             end
             @testset "WKT" begin
                 wkt = WKG.getwkt(geom)
                 wktc = ArchGDAL.toWKT(geom)
-                @test wkt == wktc
+                @test GFT.val(wkt) == wktc
                 # Test validity by reading it again
-                ArchGDAL.fromWKT(wkt)
-                gwkt = GFT.WellKnownText(GFT.Geom(), wkt)
+                ArchGDAL.fromWKT(GFT.val(wkt))
                 if type !== "Empty"  # broken on ArchGDAL
-                    @test all(GI.coordinates(gwkt) .== GI.coordinates(geom))
+                    @test all(GI.coordinates(wkt) .== GI.coordinates(geom))
                 end
             end
         end
@@ -57,19 +55,17 @@ import ArchGDAL
             @testset "WKB" begin
                 wkb = WKG.getwkb(collection)
                 wkbc = ArchGDAL.toWKB(collection)
-                @test length(wkb) == length(wkbc)
-                @test all(wkb .== wkbc)
-                collection = ArchGDAL.fromWKB(wkb)
-                gwkb = GFT.WellKnownBinary(GFT.Geom(), wkb)
-                @test all(GI.coordinates(gwkb) .== GI.coordinates(collection))
+                @test length(GFT.val(wkb)) == length(wkbc)
+                @test all(GFT.val(wkb) .== wkbc)
+                collection = ArchGDAL.fromWKB(GFT.val(wkb))
+                @test all(GI.coordinates(wkb) .== GI.coordinates(collection))
             end
             @testset "WKT" begin
                 wkt = WKG.getwkt(collection)
                 wktc = ArchGDAL.toWKT(collection)
-                @test wkt == wktc
-                collection = ArchGDAL.fromWKT(wkt)
-                gwkb = GFT.WellKnownText(GFT.Geom(), wkt)
-                @test all(GI.coordinates(gwkb) .== GI.coordinates(collection))
+                @test GFT.val(wkt) == wktc
+                collection = ArchGDAL.fromWKT(GFT.val(wkt))
+                @test all(GI.coordinates(wkt) .== GI.coordinates(collection))
 
             end
         end
@@ -88,6 +84,6 @@ import ArchGDAL
 
         wkt = GFT.WellKnownText(GFT.Geom(), "LINESTRING (30.0 10.0, 10.0 30.0, 40.0 40.0)")
         @test GI.testgeometry(wkt)
-        @test GI.coordinates(wkt) == [[30.0,10.0],[10.0,30.0],[40.0,40.0]]
+        @test GI.coordinates(wkt) == [[30.0, 10.0], [10.0, 30.0], [40.0, 40.0]]
     end
 end


### PR DESCRIPTION
fixes #15.

Otherwise users need to do `GeoFormatTypes.WellKnownText(GeoFormatTypes.Geom(), getwkb(geom))` themselves for exchange in the ecosystem (i.e. GeoParquet).

This also makes it possible for eventually parsing the CRS information in a WKT/WKB string, and setting GeoFormatTypes.Mixed().