### PR TITLE
Improve WKB performance.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
+    warnonly=[:missing_docs],
 )
 
 deploydocs(;


### PR DESCRIPTION
Given 

```julia
using WellKnownGeometry
julia> n = 1_000_000
1000000

julia> points = zip(rand(n), rand(n));
```

### New
```julia
julia> @time getwkb.(points);
  0.249585 seconds (2.36 M allocations: 138.888 MiB, 12.17% gc time, 37.81% compilation time)

julia> @time getwkb.(points);
  0.180918 seconds (2.00 M allocations: 114.441 MiB, 26.30% gc time)
```

### Before
```julia
julia> @time getwkb.(points);
  0.310216 seconds (6.19 M allocations: 371.373 MiB, 29.10% gc time, 13.66% compilation time: 100% of which was recompilation)

julia> @time getwkb.(points);
  0.380223 seconds (6.00 M allocations: 358.582 MiB, 50.55% gc time)
```