### PR TITLE
Add coordtype implementation

### DIFF
--- a/src/wkb.jl
+++ b/src/wkb.jl
@@ -308,3 +308,8 @@ function typesize(T::GI.GeometryCollectionTrait, geom, n::Integer)
 end
 
 GI.asbinary(::GI.AbstractGeometryTrait, geom) = WellKnownGeometry.getwkb(geom)
+
+# coordtype implementation - WellKnownGeometry always uses Float64
+if :coordtype in names(GI; all = true)
+    GI.coordtype(::GI.AbstractGeometryTrait, geom::WKBtype) = Float64
+end

--- a/src/wkt.jl
+++ b/src/wkt.jl
@@ -248,3 +248,8 @@ function GI.getgeom(
 end
 
 GI.astext(::GI.AbstractGeometryTrait, geom) = getwkt(geom)
+
+# coordtype implementation - WellKnownGeometry always uses Float64
+if :coordtype in names(GI; all = true)
+    GI.coordtype(::GI.AbstractGeometryTrait, geom::WKTtype) = Float64
+end


### PR DESCRIPTION
Implements GeoInterface.coordtype for WKB and WKT types. Returns Float64.

🤖 Generated with [Claude Code](https://claude.ai/code)